### PR TITLE
Add text justification

### DIFF
--- a/cover.tex
+++ b/cover.tex
@@ -13,6 +13,12 @@
 \rfoot{Page \thepage \hspace{1pt}}
 \thispagestyle{empty}
 \renewcommand{\headrulewidth}{0pt}
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%     Justifying
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+\usepackage{ragged2e}
+\renewcommand{\lettercontent}[1]{\justifying\noindent\fontspec[Path = OpenFonts/fonts/raleway/]{Raleway-Medium}\fontsize{11pt}{13pt}\selectfont {#1 \\}\mbox{}\\ \normalfont}
 \begin{document}
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%


### PR DESCRIPTION
Add text justification

This commit introducese changes to the document layout and styling:
- Added the 'ragged2e' package for text justification.
- Modified the 'lettercontent' command to use the 'Raleway-Medium' font.
- Adjusted the font size and line spacing.

These changes improve the readability and appearance of the document.